### PR TITLE
fix/ignore_vector_index

### DIFF
--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from logging.config import fileConfig
 
 from alembic import context
@@ -47,6 +48,8 @@ def get_metadata():
 
 def include_object(object, name, type_, reflected, compare_to):
     if type_ == "foreign_key_constraint":
+        return False
+    elif type_ == "table" and re.match(r"^embedding_vector_index_.*?_nod$", name):
         return False
     else:
         return True


### PR DESCRIPTION
# Summary

Tables like embedding_vector_index_ are ignored during database migration.
Avoid having to manually modify the migration file every time you migrate the database.
> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

